### PR TITLE
cards/surface: allow to change border without loosing ripple effect

### DIFF
--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/NavGraph.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/NavGraph.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 import kiwi.orbit.compose.catalog.screens.AlertScreen
 import kiwi.orbit.compose.catalog.screens.BadgeScreen
 import kiwi.orbit.compose.catalog.screens.ButtonScreen
+import kiwi.orbit.compose.catalog.screens.CardsScreen
 import kiwi.orbit.compose.catalog.screens.CheckboxScreen
 import kiwi.orbit.compose.catalog.screens.ColorsScreen
 import kiwi.orbit.compose.catalog.screens.IconsScreen
@@ -33,6 +34,7 @@ private object MainDestinations {
     const val ALERT = "alert"
     const val BADGE = "badge"
     const val BUTTON = "button"
+    const val CARDS = "cards"
     const val CHECKBOX = "checkbox"
     const val RADIO = "radio"
     const val STEPPER = "stepper"
@@ -80,6 +82,9 @@ fun NavGraph(
         }
         composable(MainDestinations.BUTTON) {
             ButtonScreen(actions::navigateUp)
+        }
+        composable(MainDestinations.CARDS) {
+            CardsScreen(actions::navigateUp)
         }
         composable(MainDestinations.CHECKBOX) {
             CheckboxScreen(actions::navigateUp)
@@ -139,6 +144,10 @@ class MainActions(
 
     fun showButton() {
         navController.navigate(MainDestinations.BUTTON)
+    }
+
+    fun showCards() {
+        navController.navigate(MainDestinations.CARDS)
     }
 
     fun showCheckbox() {

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/CardsScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/CardsScreen.kt
@@ -1,0 +1,74 @@
+package kiwi.orbit.compose.catalog.screens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kiwi.orbit.compose.catalog.SubScreen
+import kiwi.orbit.compose.illustrations.Illustrations
+import kiwi.orbit.compose.ui.OrbitTheme
+import kiwi.orbit.compose.ui.controls.Card
+import kiwi.orbit.compose.ui.controls.Separator
+import kiwi.orbit.compose.ui.controls.Text
+
+@Composable
+fun CardsScreen(onUpClick: () -> Unit) {
+    SubScreen(
+        title = "Cards / Tiles",
+        onUpClick = onUpClick,
+        withBackground = false,
+    ) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CardScreenInner()
+        }
+    }
+}
+
+@Composable
+private fun CardScreenInner() {
+    var state by remember { mutableStateOf(true) }
+
+    Card(Modifier.fillMaxWidth()) {
+        Box(Modifier.padding(16.dp)) {
+            Text("Basic card")
+        }
+    }
+
+    Separator()
+    Text("Selectable cards")
+
+    Card(
+        onClick = { state = true },
+        border = if (state) {
+            BorderStroke(2.dp, OrbitTheme.colors.interactive.main)
+        } else null,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Image(Illustrations.AirportShuttle, contentDescription = null)
+    }
+
+    Card(
+        onClick = { state = false },
+        border = if (!state) {
+            BorderStroke(2.dp, OrbitTheme.colors.interactive.main)
+        } else null,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Image(Illustrations.AirHelp, contentDescription = null)
+    }
+}

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/MainScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/MainScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.rounded.Article
 import androidx.compose.material.icons.rounded.BrightnessMedium
 import androidx.compose.material.icons.rounded.CheckBox
 import androidx.compose.material.icons.rounded.FormatSize
@@ -54,6 +55,7 @@ fun MainScreen(
         Triple("Alert", { Icon(Icons.Alert, null) }, actions::showAlert),
         Triple("Badge", { Icon(Icons.Deals, null) }, actions::showBadge),
         Triple("Button", { Icon(MaterialIcons.SmartButton, null) }, actions::showButton),
+        Triple("Cards / Tiles", { Icon(MaterialIcons.Article, null) }, actions::showCards),
         Triple("Checkbox", { Icon(MaterialIcons.CheckBox, null) }, actions::showCheckbox),
         Triple("Radio", { Icon(Icons.CircleFilled, null) }, actions::showRadio),
         Triple("Stepper", { Icon(Icons.PlusCircle, null) }, actions::showStepper),

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Card.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Card.kt
@@ -22,7 +22,7 @@ public fun Card(
     backgroundColor: Color = OrbitTheme.colors.surface.main,
     contentColor: Color = contentColorFor(backgroundColor),
     border: BorderStroke? = null,
-    elevation: Dp = 1.dp,
+    elevation: Dp = 2.dp,
     content: @Composable () -> Unit
 ) {
     Surface(
@@ -44,7 +44,7 @@ public fun Card(
     backgroundColor: Color = OrbitTheme.colors.surface.main,
     contentColor: Color = contentColorFor(backgroundColor),
     border: BorderStroke? = null,
-    elevation: Dp = 1.dp,
+    elevation: Dp = 2.dp,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     indication: Indication? = LocalIndication.current,
     enabled: Boolean = true,

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Surface.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Surface.kt
@@ -102,13 +102,10 @@ private fun Surface(
         Box(
             modifier
                 .shadow(elevation, shape, clip = false)
-                .then(if (border != null) Modifier.border(border, shape) else Modifier)
-                .background(
-                    color = color,
-                    shape = shape
-                )
                 .clip(shape)
-                .then(clickAndSemanticsModifier),
+                .then(clickAndSemanticsModifier)
+                .then(if (border != null) Modifier.border(border, shape) else Modifier)
+                .background(color, shape),
             propagateMinConstraints = true
         ) {
             content()


### PR DESCRIPTION
Fixed ripple for selectable cards & added mini demo.

<details>
<summary>Demo screen</summary>

![image](https://user-images.githubusercontent.com/284263/134501794-9ed41651-0d30-41c8-a9ff-981318a9162b.png)

</details>
