### PR TITLE
TextField sizing supporting smaller & intrinsic sizes

### DIFF
--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TextFieldScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TextFieldScreen.kt
@@ -1,13 +1,17 @@
 package kiwi.orbit.compose.catalog.screens
 
 import android.util.Patterns
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -138,7 +142,6 @@ private fun TextFieldScreenInner() {
                 .focusRequester(nationalityFocusRequester),
         )
 
-
         Spacer(Modifier.height(16.dp))
 
         var bio by rememberSaveable { mutableStateOf("") }
@@ -156,5 +159,37 @@ private fun TextFieldScreenInner() {
                 .fillMaxWidth()
                 .focusRequester(bioFocusRequester),
         )
+
+        Spacer(Modifier.height(32.dp))
+        Text("Sizing")
+        Spacer(Modifier.height(16.dp))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            var v1 by remember { mutableStateOf("") }
+            TextField(v1, { v1 = it }, label = { Text("A") })
+
+            var v2 by remember { mutableStateOf("") }
+            TextField(v2, { v2 = it }, label = { Text("B") })
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            var v1 by remember { mutableStateOf("") }
+            TextField(v1, { v1 = it }, label = { Text("A") }, modifier = Modifier.weight(1f))
+
+            var v2 by remember { mutableStateOf("") }
+            TextField(v2, { v2 = it }, label = { Text("B") }, modifier = Modifier.weight(1f))
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.width(IntrinsicSize.Max)) {
+            var v1 by remember { mutableStateOf("") }
+            TextField(v1, { v1 = it }, label = { Text("Long label") }, modifier = Modifier.fillMaxWidth())
+
+            var v2 by remember { mutableStateOf("") }
+            TextField(v2, { v2 = it }, label = { Text("Label") }, modifier = Modifier.fillMaxWidth())
+        }
     }
 }

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TextFieldScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TextFieldScreen.kt
@@ -98,36 +98,12 @@ private fun TextFieldScreenInner() {
             ),
             keyboardActions = KeyboardActions(
                 onNext = {
-                    bioFocusRequester.requestFocus()
-                },
-            ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(passwordFocusRequester),
-        )
-
-        Spacer(Modifier.height(16.dp))
-
-        var bio by rememberSaveable { mutableStateOf("") }
-        TextField(
-            value = bio,
-            onValueChange = { bio = it },
-            label = { Text("Bio") },
-            info = { Text("Three words about you.") },
-            leadingIcon = { Icon(Icons.Linkedin, contentDescription = null) },
-            singleLine = false,
-            keyboardOptions = KeyboardOptions.Default.copy(
-                keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Next,
-            ),
-            keyboardActions = KeyboardActions(
-                onNext = {
                     nationalityFocusRequester.requestFocus()
                 },
             ),
             modifier = Modifier
                 .fillMaxWidth()
-                .focusRequester(bioFocusRequester),
+                .focusRequester(passwordFocusRequester),
         )
 
         Spacer(Modifier.height(16.dp))
@@ -148,10 +124,37 @@ private fun TextFieldScreenInner() {
                 null
             },
             info = { Text("A nationality code or full name.") },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Next,
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = {
+                    bioFocusRequester.requestFocus()
+                },
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(nationalityFocusRequester),
+        )
+
+
+        Spacer(Modifier.height(16.dp))
+
+        var bio by rememberSaveable { mutableStateOf("") }
+        TextField(
+            value = bio,
+            onValueChange = { bio = it },
+            label = { Text("Bio") },
+            info = { Text("Three lines about you.") },
+            leadingIcon = { Icon(Icons.Linkedin, contentDescription = null) },
+            singleLine = false,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Text,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(bioFocusRequester),
         )
     }
 }

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/TextField.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/TextField.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -108,7 +107,6 @@ public fun TextField(
                     }
                 },
                 modifier = Modifier
-                    .fillMaxWidth()
                     .border(1.dp, borderColor.value, OrbitTheme.shapes.normal)
                     .background(backgroundColor.value, OrbitTheme.shapes.normal),
                 enabled = enabled,
@@ -123,7 +121,7 @@ public fun TextField(
                 cursorBrush = SolidColor(OrbitTheme.colors.interactive.main),
                 decorationBox = { innerTextField ->
                     FieldContent(
-                        innerContent = innerTextField,
+                        fieldContent = innerTextField,
                         placeholder = when (textFieldValue.text.isEmpty()) {
                             true -> placeholder
                             false -> null

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/TextField.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/TextField.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -26,6 +25,7 @@ import kiwi.orbit.compose.ui.OrbitTheme
 import kiwi.orbit.compose.ui.controls.field.FieldContent
 import kiwi.orbit.compose.ui.controls.field.FieldLabel
 import kiwi.orbit.compose.ui.controls.field.FieldMessage
+import kiwi.orbit.compose.ui.controls.internal.ColumnWithMinConstraints
 import kiwi.orbit.compose.ui.foundation.LocalTextStyle
 import kiwi.orbit.compose.ui.foundation.ProvideMergedTextStyle
 
@@ -51,7 +51,7 @@ public fun TextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
-    Column(modifier) {
+    ColumnWithMinConstraints(modifier) {
         ProvideMergedTextStyle(OrbitTheme.typography.bodyNormal) {
             var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = value)) }
             val textFieldValue = textFieldValueState.copy(text = value)

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/field/FieldContent.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/field/FieldContent.kt
@@ -1,117 +1,270 @@
 package kiwi.orbit.compose.ui.controls.field
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.LayoutIdParentData
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
-import kiwi.orbit.compose.ui.controls.IconButton
+import kiwi.orbit.compose.ui.OrbitTheme
 import kiwi.orbit.compose.ui.foundation.ContentEmphasis
 import kiwi.orbit.compose.ui.foundation.ProvideContentEmphasis
+import kiwi.orbit.compose.ui.foundation.ProvideMergedTextStyle
+import kotlin.math.max
+import kotlin.math.roundToInt
 
 @Composable
 internal fun FieldContent(
-    innerContent: @Composable () -> Unit,
-    placeholder: @Composable (() -> Unit)? = null,
-    leadingIcon: @Composable (() -> Unit)? = null,
-    onLeadingIconClick: (() -> Unit)? = null,
-    trailingIcon: @Composable (() -> Unit)? = null,
-    onTrailingIconClick: (() -> Unit)? = null,
-    singleLine: Boolean = true,
+    fieldContent: @Composable () -> Unit,
+    placeholder: @Composable (() -> Unit)?,
+    leadingIcon: @Composable (() -> Unit)?,
+    onLeadingIconClick: (() -> Unit)?,
+    trailingIcon: @Composable (() -> Unit)?,
+    onTrailingIconClick: (() -> Unit)?,
+    singleLine: Boolean,
+    modifier: Modifier = Modifier,
 ) {
+    val measurePolicy = remember(singleLine) {
+        FieldContentMeasurePolicy(singleLine)
+    }
     Layout(
         content = {
             if (leadingIcon != null) {
-                Box(Modifier.layoutId("leading")) {
-                    if (onLeadingIconClick != null) {
-                        IconButton(
-                            onClick = onLeadingIconClick,
-                            rippleRadius = RippleRadius,
-                        ) {
-                            leadingIcon()
-                        }
-                    } else {
-                        leadingIcon()
-                    }
-                }
+                FieldIcon(LeadingId, onLeadingIconClick, leadingIcon, Modifier.padding(start = FieldIconPadding))
             }
             if (trailingIcon != null) {
-                Box(Modifier.layoutId("trailing")) {
-                    if (onTrailingIconClick != null) {
-                        IconButton(
-                            onClick = onTrailingIconClick,
-                            rippleRadius = RippleRadius,
-                        ) {
-                            trailingIcon()
-                        }
-                    } else {
-                        trailingIcon()
+                FieldIcon(TrailingId, onTrailingIconClick, trailingIcon, Modifier.padding(end = FieldIconPadding))
+            }
+
+            val padding = Modifier.padding(
+                start = if (leadingIcon != null) FieldIconSeparatorPadding else FieldPadding,
+                end = if (trailingIcon != null) FieldIconSeparatorPadding else FieldPadding,
+            )
+
+            if (placeholder != null) {
+                Box(Modifier.layoutId(PlaceholderId).then(padding)) {
+                    ProvideMergedTextStyle(OrbitTheme.typography.bodyNormal) {
+                        ProvideContentEmphasis(ContentEmphasis.Subtle, content = placeholder)
                     }
                 }
             }
-            if (placeholder != null) {
-                Box(Modifier.layoutId("placeholder")) {
-                    ProvideContentEmphasis(ContentEmphasis.Subtle, content = placeholder)
-                }
-            }
-            Box(Modifier.layoutId("textField")) {
-                innerContent()
+            Box(
+                Modifier.layoutId(FieldId).then(padding),
+                propagateMinConstraints = true,
+            ) {
+                fieldContent()
             }
         },
-    ) { measurables, incomingConstraints ->
-        val constraints = incomingConstraints.copy(minWidth = 0, minHeight = 0)
-        val padding = 12.dp.roundToPx()
+        modifier = modifier,
+        measurePolicy = measurePolicy,
+    )
+}
 
-        val leadingPlaceable = measurables.find { it.layoutId == "leading" }
-            ?.measure(constraints)
-        val leadingWidth = leadingPlaceable?.width?.plus(padding) ?: 0
+private class FieldContentMeasurePolicy(
+    val singleLine: Boolean,
+) : MeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        val verticalPadding = FieldPadding.roundToPx()
+        val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+        var occupiedSpaceHorizontally = 0
 
-        val iconPaddingWidth = (24.dp - RippleRadius) * 2
-        val trailingPadding =
-            if (onTrailingIconClick != null) padding - iconPaddingWidth.roundToPx() else padding
-        val trailingPlaceable = measurables.find { it.layoutId == "trailing" }
-            ?.measure(constraints.offset(horizontal = -leadingWidth))
-        val trailingWidth = trailingPlaceable?.width?.plus(trailingPadding) ?: 0
+        val leadingPlaceable = measurables.find { it.layoutId == LeadingId }?.measure(looseConstraints)
+        occupiedSpaceHorizontally += leadingPlaceable?.width ?: 0
 
-        val occupiedHorizontally = padding * 2 + leadingWidth + trailingWidth
-        val textFieldConstraints = incomingConstraints
+        val trailingPlaceable = measurables.find { it.layoutId == TrailingId }
+            ?.measure(looseConstraints.offset(horizontal = -occupiedSpaceHorizontally))
+        occupiedSpaceHorizontally += trailingPlaceable?.width ?: 0
+
+        val fieldConstraints = constraints
             .copy(minHeight = 0)
-            .offset(horizontal = -occupiedHorizontally)
+            .offset(
+                vertical = -verticalPadding * 2,
+                horizontal = -occupiedSpaceHorizontally,
+            )
+        val fieldPlaceable = measurables.first { it.layoutId == FieldId }.measure(fieldConstraints)
 
-        val placeholderPlaceable =
-            measurables.find { it.layoutId == "placeholder" }?.measure(textFieldConstraints)
-        val textFieldPlaceable =
-            measurables.first { it.layoutId == "textField" }.measure(textFieldConstraints)
+        // Placeholder
+        val placeholderConstraints = fieldConstraints.copy(minWidth = 0)
+        val placeholderPlaceable = measurables.find { it.layoutId == PlaceholderId }?.measure(placeholderConstraints)
 
-        val width = constraints.maxWidth
-        val height = textFieldPlaceable.height + padding * 2
+        val width = calculateWidth(
+            fieldWidth = fieldPlaceable.width,
+            leadingWidth = leadingPlaceable?.width ?: 0,
+            trailingWidth = trailingPlaceable?.width ?: 0,
+            placeholderWidth = placeholderPlaceable?.width ?: 0,
+            constraints = constraints,
+        )
+        val height = calculateHeight(
+            fieldHeight = fieldPlaceable.height,
+            leadingHeight = leadingPlaceable?.height ?: 0,
+            trailingHeight = trailingPlaceable?.height ?: 0,
+            placeholderHeight = placeholderPlaceable?.height ?: 0,
+            constraints = constraints,
+            density = density,
+        )
 
-        val textVerticalPosition = if (singleLine) {
-            Alignment.CenterVertically.align(textFieldPlaceable.height, height)
-        } else {
-            padding
-        }
+        return layout(width, height) {
+            val verticalPaddingPadding = (FieldPadding.value * density).roundToInt()
 
-        layout(width, height) {
             leadingPlaceable?.placeRelative(
-                padding,
-                Alignment.CenterVertically.align(leadingPlaceable.height, height)
+                x = 0,
+                y = Alignment.CenterVertically.align(leadingPlaceable.height, height)
             )
             trailingPlaceable?.placeRelative(
-                width - trailingWidth,
-                Alignment.CenterVertically.align(trailingPlaceable.height, height)
+                x = width - trailingPlaceable.width,
+                y = Alignment.CenterVertically.align(trailingPlaceable.height, height)
             )
-            placeholderPlaceable?.placeRelative(
-                padding + leadingWidth,
-                textVerticalPosition,
-                zIndex = 1f
+
+            // Single line text field without label places its input center vertically. Multiline text
+            // field without label places its input at the top with padding
+            val fieldVerticalPosition = if (singleLine) {
+                Alignment.CenterVertically.align(fieldPlaceable.height, height)
+            } else {
+                verticalPaddingPadding
+            }
+            fieldPlaceable.placeRelative(
+                x = leadingPlaceable?.width ?: 0,
+                y = fieldVerticalPosition,
+                zIndex = 1f,
             )
-            textFieldPlaceable.placeRelative(padding + leadingWidth, textVerticalPosition)
+
+            // placeholder is placed similar to the text input above
+            if (placeholderPlaceable != null) {
+                val placeholderVerticalPosition = if (singleLine) {
+                    Alignment.CenterVertically.align(placeholderPlaceable.height, height)
+                } else {
+                    verticalPaddingPadding
+                }
+                placeholderPlaceable.placeRelative(
+                    x = leadingPlaceable?.width ?: 0,
+                    y = placeholderVerticalPosition,
+                )
+            }
         }
+    }
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int
+    ): Int {
+        return intrinsicHeight(measurables, width, IntrinsicMeasurable::maxIntrinsicHeight)
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int
+    ): Int {
+        return intrinsicHeight(measurables, width, IntrinsicMeasurable::minIntrinsicHeight)
+    }
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int
+    ): Int {
+        return intrinsicWidth(measurables, height, IntrinsicMeasurable::maxIntrinsicWidth)
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int
+    ): Int {
+        return intrinsicWidth(measurables, height, IntrinsicMeasurable::minIntrinsicWidth)
+    }
+
+    private fun intrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int,
+        intrinsicMeasurer: IntrinsicMeasurable.(Int) -> Int,
+    ): Int {
+        val fieldWidth = measurables.first { it.layoutId == FieldId }.intrinsicMeasurer(height)
+        val leadingWidth = measurables.find { it.layoutId == LeadingId }?.intrinsicMeasurer(height) ?: 0
+        val trailingWidth = measurables.find { it.layoutId == TrailingId }?.intrinsicMeasurer(height) ?: 0
+        val placeholderWidth = measurables.find { it.layoutId == PlaceholderId }?.intrinsicMeasurer(height) ?: 0
+        return calculateWidth(
+            fieldWidth = fieldWidth,
+            leadingWidth = leadingWidth,
+            trailingWidth = trailingWidth,
+            placeholderWidth = placeholderWidth,
+            constraints = ZeroConstraints
+        )
+    }
+
+    private fun IntrinsicMeasureScope.intrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int,
+        intrinsicMeasurer: IntrinsicMeasurable.(Int) -> Int,
+    ): Int {
+        val fieldHeight = measurables.first { it.layoutId == FieldId }.intrinsicMeasurer(width)
+        val leadingHeight = measurables.find { it.layoutId == LeadingId }?.intrinsicMeasurer(width) ?: 0
+        val trailingHeight = measurables.find { it.layoutId == TrailingId }?.intrinsicMeasurer(width) ?: 0
+        val placeholderHeight = measurables.find { it.layoutId == PlaceholderId }?.intrinsicMeasurer(width) ?: 0
+        return calculateHeight(
+            fieldHeight = fieldHeight,
+            leadingHeight = leadingHeight,
+            trailingHeight = trailingHeight,
+            placeholderHeight = placeholderHeight,
+            constraints = ZeroConstraints,
+            density = density
+        )
     }
 }
 
-private val RippleRadius = 20.dp
+private fun calculateWidth(
+    fieldWidth: Int,
+    leadingWidth: Int,
+    trailingWidth: Int,
+    placeholderWidth: Int,
+    constraints: Constraints
+): Int {
+    val middleSection = maxOf(fieldWidth, placeholderWidth)
+    val wrappedWidth = leadingWidth + middleSection + trailingWidth
+    return wrappedWidth.coerceAtLeast(constraints.minWidth)
+}
+
+private fun calculateHeight(
+    fieldHeight: Int,
+    leadingHeight: Int,
+    trailingHeight: Int,
+    placeholderHeight: Int,
+    constraints: Constraints,
+    density: Float
+): Int {
+    val topBottomPadding = FieldPadding.value * density
+    val middleSection = max(fieldHeight, placeholderHeight)
+    val wrappedHeight = topBottomPadding * 2 + middleSection
+
+    return maxOf(
+        wrappedHeight.roundToInt(),
+        max(leadingHeight, trailingHeight),
+        constraints.minHeight
+    )
+}
+
+internal val IntrinsicMeasurable.layoutId: Any?
+    get() = (parentData as? LayoutIdParentData)?.layoutId
+
+private val ZeroConstraints = Constraints(0, 0, 0, 0)
+
+private val FieldPadding = 12.dp
+private val FieldIconPadding = 14.dp
+private val FieldIconSeparatorPadding = 10.dp
+
+private const val FieldId = "Field"
+private const val PlaceholderId = "Placeholder"
+private const val LeadingId = "Leading"
+private const val TrailingId = "Trailing"

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/field/FieldIcon.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/field/FieldIcon.kt
@@ -1,0 +1,35 @@
+package kiwi.orbit.compose.ui.controls.field
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.unit.dp
+import kiwi.orbit.compose.ui.controls.IconButton
+
+@Composable
+internal fun FieldIcon(
+    layoutId: String,
+    onClick: (() -> Unit)?,
+    icon: @Composable () -> Unit,
+    modifier: Modifier,
+) {
+    Box(
+        modifier
+            .layoutId(layoutId)
+            .sizeIn(maxWidth = 20.dp, maxHeight = 20.dp)
+    ) {
+        if (onClick != null) {
+            IconButton(
+                onClick = onClick,
+                rippleRadius = RippleRadius,
+                content = icon
+            )
+        } else {
+            icon()
+        }
+    }
+}
+
+private val RippleRadius = 20.dp

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/field/FieldMessage.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/field/FieldMessage.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.with
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -72,6 +73,9 @@ internal fun FieldMessage(
                     message.content.invoke()
                 }
             }
+        } else {
+            // Workaround to prevent shrinking in case of propagated min constraints to fill width.
+            Box {}
         }
     }
 }

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/internal/ColumnWithMinConstraints.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/internal/ColumnWithMinConstraints.kt
@@ -1,0 +1,66 @@
+package kiwi.orbit.compose.ui.controls.internal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+
+/**
+ * Simple Column implementation with Box's propagateMinConstraints=true behavior.
+ */
+@Composable
+internal fun ColumnWithMinConstraints(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Layout(
+        modifier = modifier,
+        content = {
+            content()
+        },
+        measurePolicy = remember {
+            ColumnWithMinConstraintsMeasurePolicy()
+        },
+    )
+}
+
+private class ColumnWithMinConstraintsMeasurePolicy : MeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints
+    ): MeasureResult {
+        var occupiedSpaceVertically = 0
+        val placeables = measurables.map { measurable ->
+            val placeable = measurable.measure(
+                constraints.copy(
+                    maxHeight = if (constraints.maxHeight == Constraints.Infinity) {
+                        Constraints.Infinity
+                    } else {
+                        constraints.maxHeight - occupiedSpaceVertically
+                    }
+                )
+            )
+            occupiedSpaceVertically += placeable.height
+            placeable
+        }
+
+        val width = placeables.maxOf { it.width }.coerceAtLeast(constraints.minWidth)
+        val height = occupiedSpaceVertically.coerceAtLeast(constraints.minHeight)
+
+        return layout(width, height) {
+            var offsetY = 0
+            placeables.forEach { placeable ->
+                placeable.placeRelative(
+                    x = 0,
+                    y = offsetY,
+                )
+                offsetY += placeable.height
+            }
+        }
+    }
+}


### PR DESCRIPTION
Until now, every TextField automatically took the maxWidth, but not only the "available", but could also cause expand the parent.

This PR implements proper sizing behavior and adds intrinsic sizing support.

Showcase of intrinsic sizing:

https://user-images.githubusercontent.com/284263/143468816-50d9dcb2-98f7-42d7-891d-205c88b71613.mp4


