### PR TITLE
Add `Toast()` and `Scaffold()` component

### DIFF
--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/NavGraph.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/NavGraph.kt
@@ -26,6 +26,7 @@ import kiwi.orbit.compose.catalog.screens.StepperScreen
 import kiwi.orbit.compose.catalog.screens.SwitchScreen
 import kiwi.orbit.compose.catalog.screens.TagScreen
 import kiwi.orbit.compose.catalog.screens.TextFieldScreen
+import kiwi.orbit.compose.catalog.screens.ToastScreen
 import kiwi.orbit.compose.catalog.screens.TypographyScreen
 
 private object MainDestinations {
@@ -51,6 +52,7 @@ private object MainDestinations {
     const val SWITCH = "switch"
     const val TAG = "tag"
     const val TEXT_FIELD = "text_field"
+    const val TOAST = "toast"
 }
 
 @Composable
@@ -129,6 +131,9 @@ fun NavGraph(
         }
         composable(MainDestinations.TEXT_FIELD) {
             TextFieldScreen(actions::navigateUp)
+        }
+        composable(MainDestinations.TOAST) {
+            ToastScreen(actions::navigateUp)
         }
     }
 }
@@ -214,5 +219,9 @@ class MainActions(
 
     fun showTextField() {
         navController.navigate(MainDestinations.TEXT_FIELD)
+    }
+
+    fun showToast() {
+        navController.navigate(MainDestinations.TOAST)
     }
 }

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/Screen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/Screen.kt
@@ -13,6 +13,7 @@ import com.google.accompanist.insets.rememberInsetsPaddingValues
 import kiwi.orbit.compose.ui.OrbitTheme
 import kiwi.orbit.compose.ui.controls.Scaffold
 import kiwi.orbit.compose.ui.controls.Text
+import kiwi.orbit.compose.ui.controls.ToastHostState
 import kiwi.orbit.compose.ui.controls.TopAppBar
 
 @Composable
@@ -20,9 +21,11 @@ fun Screen(
     title: String,
     onUpClick: () -> Unit,
     withBackground: Boolean = true,
+    toastHostState: ToastHostState = remember { ToastHostState() },
     content: @Composable (contentPadding: PaddingValues) -> Unit,
 ) {
     Scaffold(
+        toastHostState = toastHostState,
         topBar = {
             TopAppBar(
                 title = { Text(text = title) },

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/Screen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/Screen.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.Modifier
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.derivedWindowInsetsTypeOf
 import com.google.accompanist.insets.rememberInsetsPaddingValues
-import kiwi.orbit.compose.catalog.components.Scaffold
 import kiwi.orbit.compose.ui.OrbitTheme
+import kiwi.orbit.compose.ui.controls.Scaffold
 import kiwi.orbit.compose.ui.controls.Text
 import kiwi.orbit.compose.ui.controls.TopAppBar
 

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/MainScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/MainScreen.kt
@@ -29,12 +29,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.insets.navigationBarsPadding
 import kiwi.orbit.compose.catalog.MainActions
-import kiwi.orbit.compose.catalog.components.Scaffold
 import kiwi.orbit.compose.icons.Icons
 import kiwi.orbit.compose.ui.OrbitTheme
 import kiwi.orbit.compose.ui.controls.Card
 import kiwi.orbit.compose.ui.controls.Icon
 import kiwi.orbit.compose.ui.controls.IconButton
+import kiwi.orbit.compose.ui.controls.Scaffold
 import kiwi.orbit.compose.ui.controls.Text
 import kiwi.orbit.compose.ui.controls.TopAppBar
 import androidx.compose.material.icons.Icons.Rounded as MaterialIcons

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/MainScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/MainScreen.kt
@@ -11,12 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.rounded.Announcement
 import androidx.compose.material.icons.rounded.Article
 import androidx.compose.material.icons.rounded.Ballot
 import androidx.compose.material.icons.rounded.BrightnessMedium
 import androidx.compose.material.icons.rounded.CheckBox
 import androidx.compose.material.icons.rounded.FormatSize
-import androidx.compose.material.icons.rounded.Input
+import androidx.compose.material.icons.rounded.Keyboard
 import androidx.compose.material.icons.rounded.LabelImportant
 import androidx.compose.material.icons.rounded.MenuOpen
 import androidx.compose.material.icons.rounded.Palette
@@ -65,7 +66,8 @@ fun MainScreen(
         Triple("Stepper", { Icon(Icons.PlusCircle, null) }, actions::showStepper),
         Triple("Switch", { Icon(MaterialIcons.ToggleOn, null) }, actions::showSwitch),
         Triple("Tag", { Icon(MaterialIcons.LabelImportant, null) }, actions::showTag),
-        Triple("Text Field", { Icon(MaterialIcons.Input, null) }, actions::showTextField),
+        Triple("Text Field", { Icon(MaterialIcons.Keyboard, null) }, actions::showTextField),
+        Triple("Toast", { Icon(MaterialIcons.Announcement, null) }, actions::showToast),
     )
 
     Scaffold(

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/ToastScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/ToastScreen.kt
@@ -1,0 +1,91 @@
+package kiwi.orbit.compose.catalog.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
+import kiwi.orbit.compose.catalog.Screen
+import kiwi.orbit.compose.icons.Icons
+import kiwi.orbit.compose.ui.controls.ButtonSecondary
+import kiwi.orbit.compose.ui.controls.Text
+import kiwi.orbit.compose.ui.controls.ToastHostState
+import kotlinx.coroutines.launch
+
+@Composable
+fun ToastScreen(
+    onUpClick: () -> Unit,
+) {
+    val toastHostState = remember { ToastHostState() }
+    val scope = rememberCoroutineScope()
+    Screen(
+        title = "Toast",
+        onUpClick = onUpClick,
+        toastHostState = toastHostState,
+    ) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(it)
+        ) {
+            ToastScreenInner { message, icon ->
+                scope.launch {
+                    toastHostState.showToast(message, icon)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToastScreenInner(
+    onToast: (String, @Composable (() -> Painter)?) -> Unit,
+) {
+    Column(
+        Modifier
+            .padding(16.dp)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(12.dp, alignment = Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        ButtonSecondary(
+            onClick = {
+                onToast("You’re signed in as jon.snow@wall.7k.") { Icons.CheckCircle }
+            },
+        ) { Text("Toast – signed in") }
+
+        ButtonSecondary(
+            onClick = {
+                onToast("Price alert was removed.") { Icons.NotificationOff }
+            },
+        ) { Text("Toast – price alert") }
+
+        ButtonSecondary(
+            onClick = {
+                onToast("We’ll notify you when the price changes.") { Icons.Notification }
+            },
+        ) { Text("Toast – price alert created") }
+
+        ButtonSecondary(
+            onClick = {
+                onToast(
+                    "On mobile there’s always a fixed width to make the Toast stand out a bit more.",
+                    null
+                )
+            },
+        ) { Text("Toast – long message") }
+
+        ButtonSecondary(
+            onClick = {
+                onToast("On mobile there’s always a fixed width to make the Toast stand out a bit more.") { Icons.AirplaneLanding }
+            },
+        ) { Text("Toast – long message 2") }
+    }
+}

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Scaffold.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Scaffold.kt
@@ -1,6 +1,7 @@
 package kiwi.orbit.compose.ui.controls
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
@@ -13,6 +14,8 @@ public fun Scaffold(
     topBar: @Composable () -> Unit = {},
     backgroundColor: Color = OrbitTheme.colors.surface.main,
     contentColor: Color = contentColorFor(backgroundColor),
+    toastHostState: ToastHostState = remember { ToastHostState() },
+    toastHost: @Composable (ToastHostState) -> Unit = { ToastHost(it) },
     content: @Composable () -> Unit
 ) {
     Surface(
@@ -34,6 +37,9 @@ public fun Scaffold(
                 val topBarHeight = topBarPlaceables.maxByOrNull { it.height }?.height ?: 0
                 val bodyContentHeight = layoutHeight - topBarHeight
 
+                val toastPlacables = subcompose("toast") { toastHost(toastHostState) }.map {
+                    it.measure(looseConstraints.copy(maxHeight = bodyContentHeight))
+                }
                 val contentPlaceables = subcompose("content", content).map {
                     it.measure(looseConstraints.copy(maxHeight = bodyContentHeight))
                 }
@@ -43,6 +49,10 @@ public fun Scaffold(
                 }
                 topBarPlaceables.forEach {
                     it.place(0, 0)
+                }
+                toastPlacables.forEach {
+                    // place it centered for tablet layouts
+                    it.place((layoutWidth - it.measuredWidth) / 2, topBarHeight)
                 }
             }
         }

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Scaffold.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Scaffold.kt
@@ -1,22 +1,25 @@
-package kiwi.orbit.compose.catalog.components
+package kiwi.orbit.compose.ui.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
 import kiwi.orbit.compose.ui.OrbitTheme
-import kiwi.orbit.compose.ui.controls.Surface
 import kiwi.orbit.compose.ui.foundation.contentColorFor
 
 @Composable
-fun Scaffold(
+public fun Scaffold(
     modifier: Modifier = Modifier,
     topBar: @Composable () -> Unit = {},
-    backgroundColor: Color = OrbitTheme.colors.surface.background,
+    backgroundColor: Color = OrbitTheme.colors.surface.main,
     contentColor: Color = contentColorFor(backgroundColor),
     content: @Composable () -> Unit
 ) {
-    Surface(modifier = modifier, color = backgroundColor, contentColor = contentColor) {
+    Surface(
+        modifier = modifier,
+        color = backgroundColor,
+        contentColor = contentColor,
+    ) {
         SubcomposeLayout { constraints ->
             val layoutWidth = constraints.maxWidth
             val layoutHeight = constraints.maxHeight

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Toast.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Toast.kt
@@ -1,0 +1,237 @@
+package kiwi.orbit.compose.ui.controls
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.calculateTargetValue
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.splineBasedDecay
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.verticalDrag
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.platform.AccessibilityManager
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kiwi.orbit.compose.icons.Icons
+import kiwi.orbit.compose.ui.OrbitTheme
+import kiwi.orbit.compose.ui.foundation.LocalContentColor
+import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+public interface ToastData {
+    public val message: String
+    public val icon: @Composable (() -> Painter)?
+
+    public val animationDuration: StateFlow<Int?>
+
+    public suspend fun run(accessibilityManager: AccessibilityManager?)
+    public fun pause()
+    public fun resume()
+    public fun dismiss()
+    public fun dismissed()
+}
+
+@Composable
+public fun Toast(
+    toastData: ToastData,
+) {
+    val animateDuration by toastData.animationDuration.collectAsState()
+    key(toastData) {
+        Toast(
+            message = toastData.message,
+            icon = toastData.icon,
+            animateDuration = animateDuration,
+            onPause = toastData::pause,
+            onResume = toastData::resume,
+            onDismissed = toastData::dismissed,
+        )
+    }
+}
+
+@Composable
+private fun Toast(
+    message: String,
+    icon: @Composable (() -> Painter)?,
+    animateDuration: Int? = 0,
+    onPause: () -> Unit = {},
+    onResume: () -> Unit = {},
+    onDismissed: () -> Unit = {},
+) {
+    val shape = OrbitTheme.shapes.normal
+    Surface(
+        modifier = Modifier
+            .padding(8.dp)
+            .widthIn(max = 520.dp)
+            .fillMaxWidth()
+            .toastGesturesDetector(onPause, onResume, onDismissed),
+        color = OrbitTheme.colors.content.normal,
+        shape = shape,
+        elevation = 6.dp,
+    ) {
+        val progress = remember { Animatable(0f) }
+        LaunchedEffect(animateDuration) {
+            if (animateDuration == null) {
+                progress.stop()
+            } else {
+                progress.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(
+                        durationMillis = animateDuration,
+                        easing = CubicBezierEasing(0f, 0f, 0.58f, 1f), // EaseOut
+                    ),
+                )
+            }
+        }
+
+        val color = LocalContentColor.current
+        Row(
+            Modifier
+                .drawBehind {
+                    val fraction = progress.value * size.width
+                    drawRoundRect(
+                        color = color,
+                        size = Size(width = fraction, height = size.height),
+                        cornerRadius = CornerRadius(6.dp.toPx()),
+                        alpha = 0.1f,
+                    )
+                }
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (icon != null) {
+                Icon(
+                    icon(),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(16.dp)
+                        .padding(top = 2.dp)
+                )
+            }
+            Text(message, style = OrbitTheme.typography.bodyNormal)
+        }
+    }
+}
+
+private fun Modifier.toastGesturesDetector(
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onDismissed: () -> Unit,
+): Modifier = composed {
+    val offsetY = remember { Animatable(0f) }
+    val alpha = remember { Animatable(1f) }
+
+    pointerInput(Unit) {
+        val decay = splineBasedDecay<Float>(this)
+        coroutineScope {
+            while (true) {
+                // Detect a touch down event.
+                val pointerId = awaitPointerEventScope {
+                    val down = awaitFirstDown()
+                    onPause()
+                    down.id
+                }
+                val velocityTracker = VelocityTracker()
+                // Stop any ongoing animation.
+                offsetY.stop()
+                alpha.stop()
+                awaitPointerEventScope {
+                    verticalDrag(pointerId) { change ->
+                        onPause()
+                        // Update the animation value with touch events.
+                        val changeY = (offsetY.value + change.positionChange().y).coerceAtMost(0f)
+                        launch {
+                            offsetY.snapTo(changeY)
+                        }
+                        if (changeY == 0f) {
+                            velocityTracker.resetTracking()
+                        } else {
+                            velocityTracker.addPosition(
+                                change.uptimeMillis,
+                                change.position
+                            )
+                        }
+                    }
+                }
+                onResume()
+                // No longer receiving touch events. Prepare the animation.
+                val velocity = velocityTracker.calculateVelocity().y
+                val targetOffsetY = decay.calculateTargetValue(
+                    offsetY.value,
+                    velocity
+                )
+                // The animation stops when it reaches the bounds.
+                offsetY.updateBounds(
+                    lowerBound = -size.height.toFloat() * 3,
+                    upperBound = size.height.toFloat(),
+                )
+                launch {
+                    if (velocity >= 0 || targetOffsetY.absoluteValue <= size.height) {
+                        // Not enough velocity; Slide back.
+                        offsetY.animateTo(
+                            targetValue = 0f,
+                            initialVelocity = velocity,
+                        )
+                    } else {
+                        // The element was swiped away.
+                        launch { offsetY.animateDecay(velocity, decay) }
+                        launch {
+                            alpha.animateTo(targetValue = 0f, animationSpec = tween(300))
+                            onDismissed()
+                        }
+                    }
+                }
+            }
+        }
+    }
+        .offset {
+            IntOffset(0, offsetY.value.roundToInt())
+        }
+        .alpha(alpha.value)
+}
+
+@Preview
+@Composable
+private fun ToastPreview() {
+    OrbitTheme {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Toast(
+                message = "Message",
+                icon = null,
+            )
+            Toast(
+                message = "Message with icon",
+                icon = { Icons.FlightNomad },
+            )
+            Toast(
+                message = "Message with icon and very long message with many words.",
+                icon = { Icons.FlightNomad },
+            )
+        }
+    }
+}

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/ToastHost.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/ToastHost.kt
@@ -1,0 +1,179 @@
+package kiwi.orbit.compose.ui.controls
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.AccessibilityManager
+import androidx.compose.ui.platform.LocalAccessibilityManager
+import kotlin.coroutines.resume
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+@Stable
+public class ToastHostState {
+    private val mutex = Mutex()
+
+    public var currentData: ToastData? by mutableStateOf(null)
+        private set
+
+    public suspend fun showToast(
+        message: String,
+        icon: @Composable (() -> Painter)?,
+    ): Unit = mutex.withLock {
+        try {
+            return suspendCancellableCoroutine { cont ->
+                currentData = ToastDataImpl(
+                    message,
+                    icon,
+                    cont,
+                )
+            }
+        } finally {
+            currentData = null
+        }
+    }
+
+    @Stable
+    private class ToastDataImpl(
+        override val message: String,
+        override val icon: @Composable (() -> Painter)?,
+        private val continuation: CancellableContinuation<Unit>,
+    ) : ToastData {
+        private var elapsed = 0L
+        private var started = 0L
+        private var duration = 0L
+        private val _state = MutableStateFlow<Int?>(null)
+        override val animationDuration: StateFlow<Int?> = _state.asStateFlow()
+
+        override suspend fun run(accessibilityManager: AccessibilityManager?) {
+            duration = durationTimeout(
+                hasIcon = icon != null,
+                accessibilityManager = accessibilityManager,
+            )
+
+            // Accessibility decided to show forever
+            // Let's await explicit dismiss, do not run animation.
+            if (duration == Long.MAX_VALUE) {
+                delay(duration)
+                return
+            }
+
+            resume()
+            supervisorScope {
+                launch {
+                    animationDuration.collectLatest {
+                        if (it != null) {
+                            started = System.currentTimeMillis()
+                            delay(it.toLong())
+                            this@launch.cancel()
+                        } else {
+                            elapsed = started - System.currentTimeMillis()
+                            delay(Long.MAX_VALUE)
+                        }
+                    }
+                }
+            }
+        }
+
+        override fun pause() {
+            _state.value = null
+        }
+
+        override fun resume() {
+            val remains = (duration - elapsed).toInt()
+            if (remains > 0) {
+                _state.value = remains
+            } else {
+                dismiss()
+            }
+        }
+
+        override fun dismiss() {
+            _state.value = 0
+        }
+
+        override fun dismissed() {
+            if (continuation.isActive) {
+                continuation.resume(Unit)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+public fun ToastHost(
+    hostState: ToastHostState,
+    modifier: Modifier = Modifier,
+    toast: @Composable (ToastData) -> Unit = { Toast(it) },
+) {
+    val accessibilityManager = LocalAccessibilityManager.current
+    val currentData = hostState.currentData ?: return
+
+    key(currentData) {
+        var state by remember { mutableStateOf(false) }
+        val transition = updateTransition(targetState = state, label = "toast")
+
+        LaunchedEffect(Unit) {
+            state = true
+            currentData.run(accessibilityManager)
+            state = false
+        }
+
+        transition.AnimatedVisibility(
+            visible = { it },
+            modifier = modifier,
+            enter = fadeIn() + slideInVertically(),
+            exit = fadeOut() + slideOutVertically(),
+        ) {
+            toast(currentData)
+        }
+
+        // Await dismiss animation and dismiss the Toast completely.
+        // This animation workaround instead of nulling the toast data is to prevent
+        // relaunching another Toast when the dismiss animation has not completed yet.
+        LaunchedEffect(state, transition.currentState, transition.isRunning) {
+            if (!state && !transition.currentState && !transition.isRunning) {
+                currentData.dismissed()
+            }
+        }
+    }
+}
+
+internal fun durationTimeout(
+    hasIcon: Boolean,
+    accessibilityManager: AccessibilityManager?,
+): Long {
+    val timeout = 5000L
+    if (accessibilityManager == null) return timeout
+    return accessibilityManager.calculateRecommendedTimeoutMillis(
+        originalTimeoutMillis = timeout,
+        containsIcons = hasIcon,
+        containsText = true,
+        containsControls = false,
+    )
+}

--- a/ui/src/main/java/kiwi/orbit/compose/ui/foundation/ContentColor.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/foundation/ContentColor.kt
@@ -11,6 +11,7 @@ import kiwi.orbit.compose.ui.OrbitTheme
 
 public fun Colors.contentColorFor(color: Color): Color =
     surface.contentColorFor(color, content)
+        ?: content.contentColorFor(color, surface)
         ?: primary.contentColorFor(color)
         ?: interactive.contentColorFor(color)
         ?: success.contentColorFor(color)
@@ -26,6 +27,15 @@ private fun SurfaceColors.contentColorFor(
         main -> contentColors.normal
         background -> contentColors.normal
         strong -> contentColors.normal
+        else -> null
+    }
+
+private fun ContentColors.contentColorFor(
+    color: Color,
+    surfaceColors: SurfaceColors,
+): Color? =
+    when (color) {
+        normal -> surfaceColors.main
         else -> null
     }
 


### PR DESCRIPTION
This is implementation of new Toast component driven by `ToastHostState` and `Scaffold()` component.

![image](https://user-images.githubusercontent.com/284263/151216143-42856f81-e149-4be0-87e6-49b840e8e420.png)

Toast is:
- properly positioned under the `TopAppBar()`, nevertheless its height;
- animating its appearance and 5-sec progress bar until it disappear;
- touchable; touch pauses the count-down;
- swipeable; swipe-up dismisses the Toast earlier; when accessibility service decide to show it indefinitely, it is the only option to dismiss it;
- "suspending", i.e. you may show many toast, they wait for previous to complete;

https://user-images.githubusercontent.com/284263/151217077-8e9a4ceb-b65a-4e17-8d67-bdf31da74161.mp4


