### PR TITLE
Add sticky actions block to `Scaffold()`

### DIFF
--- a/.idea/dictionaries/shared.xml
+++ b/.idea/dictionaries/shared.xml
@@ -1,0 +1,12 @@
+<component name="ProjectDictionaryState">
+    <dictionary name="shared">
+        <words>
+            <w>jetpack</w>
+            <w>ktlint</w>
+            <w>measurable</w>
+            <w>measurables</w>
+            <w>placeable</w>
+            <w>placeables</w>
+        </words>
+    </dictionary>
+</component>

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/Screen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/Screen.kt
@@ -14,6 +14,7 @@ import kiwi.orbit.compose.ui.controls.TopAppBar
 fun Screen(
     title: String,
     onNavigateUp: () -> Unit,
+    action: @Composable (() -> Unit)? = null,
     toastHostState: ToastHostState = remember { ToastHostState() },
     topAppBarElevation: Dp = 2.dp,
     content: @Composable (contentPadding: PaddingValues) -> Unit,
@@ -26,6 +27,7 @@ fun Screen(
                 elevation = topAppBarElevation,
             )
         },
+        action = action,
         toastHostState = toastHostState,
         content = content,
     )

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TextFieldScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TextFieldScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kiwi.orbit.compose.catalog.Screen
 import kiwi.orbit.compose.icons.Icons
+import kiwi.orbit.compose.ui.controls.ButtonPrimary
 import kiwi.orbit.compose.ui.controls.Icon
 import kiwi.orbit.compose.ui.controls.PasswordTextField
 import kiwi.orbit.compose.ui.controls.Text
@@ -41,6 +42,11 @@ fun TextFieldScreen(onNavigateUp: () -> Unit) {
     Screen(
         title = "Text Field",
         onNavigateUp = onNavigateUp,
+        action = {
+            ButtonPrimary(onClick = {}, Modifier.fillMaxWidth()) {
+                Text("Primary Action")
+            }
+        }
     ) { contentPadding ->
         Box(
             Modifier


### PR DESCRIPTION
Added gray background to visualize the bg gradient. 

Currently I'm thinking about renaming `actions` block to `action`, since the official guidance is to use just a single button.

<image src="https://user-images.githubusercontent.com/284263/153732123-a9c370d9-016b-4434-bb4c-dcba375bf7cb.png" width=350>
