### PR TITLE
Icons auto sizing (BC break)

### DIFF
--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Alert.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Alert.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -149,21 +148,21 @@ private fun Alert(
                 bottom = 16.dp,
             )
     ) {
-        if (icon != null) {
-            Icon(
-                icon,
-                contentDescription = null,
-                modifier = Modifier
-                    .padding(end = 8.dp)
-                    .size(20.dp),
-                tint = accentColor,
+        ProvideMergedTextStyle(OrbitTheme.typography.bodyNormal) {
+            if (icon != null) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp),
+                    tint = accentColor,
+                )
+            }
+            AlertContent(
+                title = title,
+                actions = actions,
+                content = content,
             )
         }
-        AlertContent(
-            title = title,
-            actions = actions,
-            content = content,
-        )
     }
 }
 
@@ -180,9 +179,7 @@ private fun AlertContent(
             ProvideMergedTextStyle(OrbitTheme.typography.bodyNormalBold) {
                 title()
             }
-            ProvideMergedTextStyle(OrbitTheme.typography.bodyNormal) {
-                content()
-            }
+            content()
             if (actions != null) {
                 AlertButtons(Modifier.padding(top = 12.dp), actions) // 16.dp-4.dp
             }

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/AlertInline.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/AlertInline.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -151,19 +150,17 @@ private fun AlertInline(
         propagateMinConstraints = true,
     ) {
         AlertInlineContent {
-            if (icon != null) {
-                Icon(
-                    icon,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .padding(end = 8.dp)
-                        .size(20.dp),
-                    tint = accentColor,
-                )
-            } else {
-                Spacer(Modifier.width(4.dp))
-            }
             ProvideMergedTextStyle(OrbitTheme.typography.bodyNormalBold) {
+                if (icon != null) {
+                    Icon(
+                        icon,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp),
+                        tint = accentColor,
+                    )
+                } else {
+                    Spacer(Modifier.width(4.dp))
+                }
                 title()
             }
             CompositionLocalProvider(

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Badge.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Badge.kt
@@ -1,11 +1,8 @@
 package kiwi.orbit.compose.ui.controls
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -189,23 +186,17 @@ private fun Badge(
     content: @Composable RowScope.() -> Unit,
 ) {
     ThemedSurface(
+        modifier = modifier,
         subtle = subtle,
         shape = RoundedCornerShape(percent = 50),
         strokeWidth = 0.5.dp,
-        modifier = modifier.requiredHeight(BadgeHeight),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
-        contentPadding = PaddingValues(horizontal = 8.dp),
+        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
     ) {
-        if (icon != null) {
-            Box(Modifier.sizeIn(maxHeight = 16.dp, maxWidth = 16.dp)) {
-                icon()
-            }
-        }
         ProvideMergedTextStyle(OrbitTheme.typography.bodySmallMedium) {
+            icon?.invoke()
             content()
         }
     }
 }
-
-internal val BadgeHeight = 24.dp

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/ChoiceTile.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/ChoiceTile.kt
@@ -73,7 +73,9 @@ private fun ChoiceTileContent(
     ) {
         if (title != null || description != null) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                icon?.invoke()
+                ProvideMergedTextStyle(OrbitTheme.typography.title3) {
+                    icon?.invoke()
+                }
 
                 Column(
                     verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/ChoiceTileCentered.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/ChoiceTileCentered.kt
@@ -6,13 +6,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -44,7 +44,12 @@ public fun ChoiceTileCentered(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .zIndex(1f)
-                    .offset(y = BadgeHeight / -2),
+                    .layout { measurable, constraints ->
+                        val placeable = measurable.measure(constraints)
+                        layout(placeable.width, placeable.height) {
+                            placeable.placeRelative(0, placeable.height / -2)
+                        }
+                    },
                 content = badgeContent,
             )
         }
@@ -87,9 +92,11 @@ private fun ChoiceTileContent(
         verticalArrangement = Arrangement.spacedBy(4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        icon?.invoke()
-
-        ProvideMergedTextStyle(OrbitTheme.typography.bodyLargeBold) {
+        // Provide default icon size to 24.dp
+        ProvideMergedTextStyle(OrbitTheme.typography.title3) {
+            icon?.invoke()
+        }
+        ProvideMergedTextStyle(OrbitTheme.typography.title3) {
             title()
         }
 

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/Icon.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/Icon.kt
@@ -15,16 +15,23 @@ import androidx.compose.ui.graphics.toolingGraphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
 import kiwi.orbit.compose.ui.foundation.ContentEmphasis
 import kiwi.orbit.compose.ui.foundation.LocalContentColor
 import kiwi.orbit.compose.ui.foundation.LocalContentEmphasis
+import kiwi.orbit.compose.ui.foundation.LocalTextStyle
 import kiwi.orbit.compose.ui.foundation.applyEmphasis
 
+/**
+ * Orbit Icon.
+ *
+ * - Size is resolved to current line-height. To modify the size, use [Modifier.size]. Defaults to 20.sp.
+ * - Color is resolved to current text color, possible to change [emphasis] or [tint] icon directly.
+ */
 @Composable
 public fun Icon(
     imageVector: ImageVector,
@@ -37,10 +44,16 @@ public fun Icon(
         painter = rememberVectorPainter(imageVector),
         contentDescription = contentDescription,
         modifier = modifier,
-        tint = tint
+        tint = tint,
     )
 }
 
+/**
+ * Orbit Icon.
+ *
+ * - Size is resolved to current line-height. To modify the size, use [Modifier.size]. Defaults to 20.sp.
+ * - Color is resolved to current text color, possible to change [emphasis] or [tint] icon directly.
+ */
 @Composable
 public fun Icon(
     bitmap: ImageBitmap,
@@ -54,7 +67,7 @@ public fun Icon(
         painter = painter,
         contentDescription = contentDescription,
         modifier = modifier,
-        tint = tint
+        tint = tint,
     )
 }
 
@@ -75,10 +88,14 @@ public fun Icon(
     } else {
         Modifier
     }
+    // Defaults icon size to 20.sp (~20.dp), bodyNormal's line-height.
+    val lineHeight = with(LocalDensity.current) {
+        LocalTextStyle.current.lineHeight.toDp()
+    }
     Box(
         modifier
             .toolingGraphicsLayer()
-            .size(24.dp)
+            .size(lineHeight)
             .paint(
                 painter,
                 colorFilter = colorFilter,


### PR DESCRIPTION
Newly we auto-size icons by local TextStyle's line-height (as defined by Orbit). This nicely coordinates icon size in different contexts and grows when text gets enlarged by system scaling.