### PR TITLE
fix dark theme

### DIFF
--- a/catalog/src/main/res/values-night/themes.xml
+++ b/catalog/src/main/res/values-night/themes.xml
@@ -1,0 +1,4 @@
+<resources>
+
+    <style name="Theme.Catalog" parent="android:Theme.Material.NoActionBar" />
+</resources>

--- a/catalog/src/main/res/values-night/themes.xml
+++ b/catalog/src/main/res/values-night/themes.xml
@@ -1,4 +1,5 @@
 <resources>
 
     <style name="Theme.Catalog" parent="android:Theme.Material.NoActionBar" />
+    
 </resources>


### PR DESCRIPTION
When having dark theme and application opens, there is a white screen flash

This PR fixes that, so if theme is dark and the app is opened, the initial color of activity is also dark