### PR TITLE
Android 13 / SDK 33

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,17 +27,7 @@ buildscript {
     }
 }
 
-repositories {
-    mavenCentral()
-}
-
 subprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url = uri("https://kotlin.bintray.com/kotlinx/") }
-    }
-
     tasks.withType<KotlinCompile>().configureEach {
         kotlinOptions {
             jvmTarget = "1.8"

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
 
     implementation(libs.androidx.core)
     implementation(libs.androidx.activityCompose)
+    implementation(libs.androidx.activityComposeCatalog)
 
     implementation(libs.compose.animation)
     implementation(libs.compose.foundation)

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         applicationId = "kiwi.orbit.compose.catalog"
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = 33
+        targetSdk = libs.versions.targetSdk.get().toInt()
         versionName = project.findProperty("VERSION_NAME").toString()
 
         val bits = versionName!!.split('.').map { it.toInt() }

--- a/catalog/src/main/AndroidManifest.xml
+++ b/catalog/src/main/AndroidManifest.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Catalog">
+        android:theme="@style/Theme.Catalog"
+        tools:ignore="UnusedAttribute">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/AppTheme.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/AppTheme.kt
@@ -1,5 +1,6 @@
 package kiwi.orbit.compose.catalog
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -30,9 +31,11 @@ fun AppTheme(
     }
 }
 
+@SuppressLint("DiscouragedApi")
 private fun createFontFamily(context: Context): FontFamily {
     val resources = context.resources
     val packageName = context.packageName
+
     val book = resources.getIdentifier("circular_pro_book", "font", packageName)
     val medium = resources.getIdentifier("circular_pro_medium", "font", packageName)
     val bold = resources.getIdentifier("circular_pro_bold", "font", packageName)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlin-serialization = "1.4.0"
 android-sdkCommon = "30.3.0"
 android-lint = "30.3.0"
 androidx-activityCompose = "1.5.1"
+androidx-activityComposeCatalog = "1.6.0"
 androidx-core = "1.8.0"
 androidx-constraint-layout = "1.0.1"
 accompanist-main = "0.25.1"
@@ -33,6 +34,7 @@ android-lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "
 android-lint-impl = { module = "com.android.tools.lint:lint", version.ref = "android-lint" }
 android-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "android-lint" }
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+androidx-activityComposeCatalog = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityComposeCatalog" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-constraintLayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "androidx-constraint-layout" }
 androidx-customView = { module = "androidx.customview:customview", version = "1.1.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 
-compileSdk = "32"
+compileSdk = "33"
+targetSdk = "33"
 minSdk = "23"
 
 kotlin-lang = "1.7.10"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,14 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://kotlin.bintray.com/kotlinx/") }
+    }
+}
+
 include(":catalog")
 include(":ui")
 include(":icons")

--- a/ui/src/test/kotlin/ScreenshotTest.kt
+++ b/ui/src/test/kotlin/ScreenshotTest.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.DeviceConfig.Companion.PIXEL_5
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.androidHome
+import app.cash.paparazzi.detectEnvironment
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
 import kiwi.orbit.compose.ui.controls.AlertCriticalPreview
@@ -66,22 +68,24 @@ internal class ScreenshotTest {
     @get:Rule
     val paparazzi = Paparazzi(
         theme = "android:Theme.Material.NoActionBar.Fullscreen",
+        renderingMode = SessionParams.RenderingMode.V_SCROLL,
+        environment = detectEnvironment().copy(
+            platformDir = "${androidHome()}/platforms/android-32",
+            compileSdkVersion = 32,
+        ),
     )
 
     private fun snapshot(content: @Composable () -> Unit) {
         paparazzi.unsafeUpdateConfig(
             deviceConfig = PIXEL_5.copy(screenHeight = 1, softButtons = false),
-            renderingMode = SessionParams.RenderingMode.V_SCROLL,
         )
         paparazzi.snapshot { content() }
         paparazzi.unsafeUpdateConfig(
             deviceConfig = PIXEL_5.copy(screenHeight = 1, softButtons = false, fontScale = 1.6f),
-            renderingMode = SessionParams.RenderingMode.V_SCROLL,
         )
         paparazzi.snapshot(name = "big") { content() }
         paparazzi.unsafeUpdateConfig(
             deviceConfig = PIXEL_5.copy(screenHeight = 1, softButtons = false, nightMode = NightMode.NIGHT),
-            renderingMode = SessionParams.RenderingMode.V_SCROLL,
         )
         paparazzi.snapshot(name = "dark") {
             // Workaround for https://github.com/cashapp/paparazzi/pull/473


### PR DESCRIPTION
Paparazzi does not support `targetSdk` `33` at the moment:

- https://github.com/cashapp/paparazzi/issues/558, 
- https://github.com/cashapp/paparazzi/issues/486 and
- https://github.com/cashapp/paparazzi/pull/487.