### PR TITLE
Text Field label & message moved to decoration box (BC break!)

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -49,7 +49,7 @@ android {
         warningsAsErrors = true
     }
 
-    packagingOptions {
+    packaging {
         resources.excludes.add("META-INF/AL2.0")
         resources.excludes.add("META-INF/LGPL2.1")
     }

--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/TextField.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/TextField.kt
@@ -110,19 +110,78 @@ internal fun TextField(
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
 ) {
-    val errorMessage = stringResource(R.string.orbit_field_default_error)
-    ColumnWithMinConstraints(
-        modifier
-            .semantics {
-                if (error != null) {
-                    this.error(errorMessage)
-                }
-            },
-    ) {
-        ProvideMergedTextStyle(OrbitTheme.typography.bodyNormal) {
-            var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = value)) }
-            val textFieldValue = textFieldValueState.copy(text = value)
+    var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = value)) }
+    val textFieldValue = textFieldValueState.copy(text = value)
 
+    // Reset input text style color to content color norma.
+    val textStyle = LocalTextStyle.current
+    val inputTextStyle = textStyle.copy(color = OrbitTheme.colors.content.normal)
+
+    val errorMessage = stringResource(R.string.orbit_field_default_error)
+
+    BasicTextField(
+        value = textFieldValue,
+        onValueChange = {
+            textFieldValueState = it
+            if (value != it.text) {
+                onValueChange(it.text)
+            }
+        },
+        modifier = modifier.semantics {
+            if (error != null) {
+                this.error(errorMessage)
+            }
+        },
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = inputTextStyle,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        visualTransformation = visualTransformation,
+        interactionSource = interactionSource,
+        cursorBrush = SolidColor(OrbitTheme.colors.info.normal),
+        decorationBox = { innerTextField ->
+            TextFiledDecorationBox(
+                innerTextField = innerTextField,
+                textFieldValue = textFieldValue,
+                label = label,
+                error = error,
+                info = info,
+                additionalContent = additionalContent,
+                placeholder = placeholder,
+                leadingIcon = leadingIcon,
+                onLeadingIconClick = onLeadingIconClick,
+                trailingIcon = trailingIcon,
+                onTrailingIconClick = onTrailingIconClick,
+                singleLine = singleLine,
+                interactionSource = interactionSource,
+            )
+        },
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun TextFiledDecorationBox(
+    innerTextField: @Composable () -> Unit,
+    textFieldValue: TextFieldValue,
+    label: @Composable (() -> Unit)?,
+    error: @Composable (() -> Unit)?,
+    info: @Composable (() -> Unit)?,
+    additionalContent: @Composable (() -> Unit)?,
+    placeholder: @Composable (() -> Unit)?,
+    leadingIcon: @Composable (() -> Unit)?,
+    onLeadingIconClick: (() -> Unit)?,
+    trailingIcon: @Composable (() -> Unit)?,
+    onTrailingIconClick: (() -> Unit)?,
+    singleLine: Boolean,
+    interactionSource: MutableInteractionSource,
+) {
+    ProvideMergedTextStyle(OrbitTheme.typography.bodyNormal) {
+        ColumnWithMinConstraints {
             if (label != null) {
                 FieldLabel(label)
             }
@@ -139,10 +198,6 @@ internal fun TextField(
                 }
             }
 
-            // If color is not provided via the text style, use content color as a default
-            val textStyle = LocalTextStyle.current
-            val mergedTextStyle = textStyle.copy(color = OrbitTheme.colors.content.normal)
-
             val transition = updateTransition(inputState, "stateTransition")
             val borderColor = transition.animateColor(
                 transitionSpec = { tween(durationMillis = AnimationDuration) },
@@ -155,42 +210,20 @@ internal fun TextField(
                 }
             }
 
-            BasicTextField(
-                value = textFieldValue,
-                onValueChange = {
-                    textFieldValueState = it
-                    if (value != it.text) {
-                        onValueChange(it.text)
-                    }
-                },
+            FieldContent(
                 modifier = Modifier
                     .border(1.dp, borderColor.value, OrbitTheme.shapes.normal)
                     .background(OrbitTheme.colors.surface.normal, OrbitTheme.shapes.normal),
-                enabled = enabled,
-                readOnly = readOnly,
-                textStyle = mergedTextStyle,
-                keyboardOptions = keyboardOptions,
-                keyboardActions = keyboardActions,
-                singleLine = singleLine,
-                maxLines = maxLines,
-                minLines = minLines,
-                visualTransformation = visualTransformation,
-                interactionSource = interactionSource,
-                cursorBrush = SolidColor(OrbitTheme.colors.info.normal),
-                decorationBox = { innerTextField ->
-                    FieldContent(
-                        fieldContent = innerTextField,
-                        placeholder = when (textFieldValue.text.isEmpty()) {
-                            true -> placeholder
-                            false -> null
-                        },
-                        leadingIcon = leadingIcon,
-                        onLeadingIconClick = onLeadingIconClick,
-                        trailingIcon = trailingIcon,
-                        onTrailingIconClick = onTrailingIconClick,
-                        singleLine = singleLine,
-                    )
+                fieldContent = innerTextField,
+                placeholder = when (textFieldValue.text.isEmpty()) {
+                    true -> placeholder
+                    false -> null
                 },
+                leadingIcon = leadingIcon,
+                onLeadingIconClick = onLeadingIconClick,
+                trailingIcon = trailingIcon,
+                onTrailingIconClick = onTrailingIconClick,
+                singleLine = singleLine,
             )
 
             additionalContent?.invoke()

--- a/ui/src/test/kotlin/kiwi/orbit/compose/ui/controls/TextFieldTest.kt
+++ b/ui/src/test/kotlin/kiwi/orbit/compose/ui/controls/TextFieldTest.kt
@@ -1,0 +1,135 @@
+package kiwi.orbit.compose.ui.controls
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertRangeInfoEquals
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class TextFieldTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testTextField() {
+        composeTestRule.setContent {
+            var value by remember { mutableStateOf("") }
+            TextField(
+                modifier = Modifier.testTag("textfield"),
+                value = value,
+                onValueChange = { value = it },
+                info = { Text("Info") },
+                error = if (value.length > 3) {
+                    @Composable { Text("Error") }
+                } else {
+                    null
+                },
+                label = { Text("Label") },
+                placeholder = { Text("Placeholder") },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        val textField = composeTestRule.onNodeWithTag("textfield")
+        textField.assert(hasEditTextExactly(""))
+        textField.assertTextEquals("Label", "Placeholder", includeEditableText = false)
+
+        textField.performClick() // focus to show info
+        textField.assertTextEquals("Label", "Placeholder", "Info", includeEditableText = false)
+
+        textField.performTextReplacement("text")
+        textField.assert(hasEditTextExactly("text"))
+        textField.assertTextEquals("Label", "Error", includeEditableText = false)
+
+        textField.performTextReplacement("te")
+        textField.assert(hasEditTextExactly("te"))
+        textField.assertTextEquals("Label", "Info", includeEditableText = false)
+    }
+
+    @Test
+    fun testPasswordField() {
+        composeTestRule.setContent {
+            var value by remember { mutableStateOf("") }
+            PasswordTextField(
+                modifier = Modifier.testTag("passwordField"),
+                value = value,
+                onValueChange = { value = it },
+                info = { Text("Info") },
+                error = if (value.length < 3) {
+                    @Composable { Text("Error") }
+                } else {
+                    null
+                },
+                label = { Text("Label") },
+                placeholder = { Text("Placeholder") },
+                strengthContent = {
+                    val s = value.length.coerceIn(0..3)
+                    PasswordStrengthIndicator(
+                        modifier = Modifier.testTag("passwordStrength"),
+                        value = (1 / 3f) * s.toFloat(),
+                        color = when (s) {
+                            0 -> PasswordStrengthColor.Weak
+                            1 -> PasswordStrengthColor.Weak
+                            2 -> PasswordStrengthColor.Medium
+                            else -> PasswordStrengthColor.Strong
+                        },
+                        label = { Text("Strength: $s") },
+                    )
+                },
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.waitForIdle()
+
+        val textField = composeTestRule.onNodeWithTag("passwordField")
+        val passwordStrength = composeTestRule.onNodeWithTag("passwordStrength", useUnmergedTree = true)
+
+        textField.assert(hasEditTextExactly(""))
+        textField.assertTextEquals(
+            "Label",
+            "Placeholder",
+            "Strength: 0",
+            "Error",
+            includeEditableText = false,
+        )
+
+        textField.performTextReplacement("text")
+        textField.assert(hasEditTextExactly("••••"))
+        textField.assertTextEquals("Label", "Strength: 3", "Info", includeEditableText = false)
+        passwordStrength.onChildAt(0).assertRangeInfoEquals(ProgressBarRangeInfo(1f, 0f..1f, 0))
+
+        textField.performTextReplacement("te")
+        textField.assert(hasEditTextExactly("••"))
+        textField.assertTextEquals("Label", "Strength: 2", "Error", includeEditableText = false)
+        passwordStrength.onChildAt(0).assertRangeInfoEquals(ProgressBarRangeInfo(2 / 3f, 0f..1f, 0))
+    }
+
+    private fun hasEditTextExactly(expected: String): SemanticsMatcher {
+        val propertyName = SemanticsProperties.EditableText.name
+        return SemanticsMatcher(
+            "$propertyName = [$expected]",
+        ) { node ->
+            val actual = node.config.getOrNull(SemanticsProperties.EditableText)
+            actual?.text == expected
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #352 and brings the following major change:

- the root Node contains all semantics actions present for the "text field" itself
- newly, fetching text field values should be easier and more straightforward. 