### PR TITLE
Fix `Tile` width calculation when contraints.width is 0 or smaller then the trailing icon width

### DIFF
--- a/ui/src/main/java/kiwi/orbit/compose/ui/controls/TileGroup.kt
+++ b/ui/src/main/java/kiwi/orbit/compose/ui/controls/TileGroup.kt
@@ -145,8 +145,9 @@ public fun TileGroupScope.Tile(
         ) { measurables, constraints ->
             val trailingWidth = measurables[1].maxIntrinsicWidth(Int.MAX_VALUE)
             val occupied = trailingWidth.takeIf { it != 0 }?.plus(12.dp.roundToPx()) ?: 0
+            val contentWidth = (constraints.maxWidth - occupied).coerceAtLeast(0)
             val contentPlaceable = measurables[0].measure(
-                Constraints.fixedWidth(width = constraints.maxWidth - occupied),
+                Constraints.fixedWidth(width = contentWidth),
             )
             val trailingPlaceable = measurables[1].measure(
                 Constraints.fixed(


### PR DESCRIPTION
… the trailing icon width

https://kiwicom.sentry.io/issues/4275653598/events/27d83e533446453b9b14b6a1b0b0ec00/?environment=Release-Google&project=5958448&referrer=next-event