### PR TITLE
Utilize more dark color for text selection

### DIFF
--- a/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/foundation/TextSelectionColors.kt
+++ b/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/foundation/TextSelectionColors.kt
@@ -6,9 +6,9 @@ import androidx.compose.runtime.remember
 
 @Composable
 internal fun rememberTextSelectionColors(colors: Colors): TextSelectionColors =
-    remember(colors.info.normal, colors.info.subtleAlt) {
+    remember(colors.info.normal) {
         TextSelectionColors(
             handleColor = colors.info.normal,
-            backgroundColor = colors.info.subtleAlt,
+            backgroundColor = colors.info.normal.copy(alpha = 0.2f),
         )
     }


### PR DESCRIPTION
closes #499

![obrazek](https://github.com/kiwicom/orbit-compose/assets/284263/bb7d547b-d0b2-4b4b-a968-7b9d84df3357)
