### PR TITLE
Toast is persisted through configuration changes

### DIFF
--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/CouponScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/CouponScreen.kt
@@ -9,29 +9,24 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kiwi.orbit.compose.catalog.AppTheme
 import kiwi.orbit.compose.catalog.semantics.SubScreenSemantics
-import kiwi.orbit.compose.icons.Icons
+import kiwi.orbit.compose.icons.IconName
 import kiwi.orbit.compose.ui.controls.Coupon
 import kiwi.orbit.compose.ui.controls.Scaffold
 import kiwi.orbit.compose.ui.controls.Text
-import kiwi.orbit.compose.ui.controls.ToastHostState
 import kiwi.orbit.compose.ui.controls.TopAppBar
-import kotlinx.coroutines.launch
+import kiwi.orbit.compose.ui.controls.rememberToastHostState
 
 @Composable
 internal fun CouponScreen(
     onNavigateUp: () -> Unit,
 ) {
-    val toastHostState = remember { ToastHostState() }
-    val coroutineScope = rememberCoroutineScope()
-
+    val toastHostState = rememberToastHostState()
     Scaffold(
         modifier = Modifier.testTag(SubScreenSemantics.Tag),
         topBar = {
@@ -50,9 +45,7 @@ internal fun CouponScreen(
         ) {
             CouponScreenInner(
                 onCouponCopied = {
-                    coroutineScope.launch {
-                        toastHostState.showToast("Copied to clipboard!") { Icons.Copy }
-                    }
+                    toastHostState.showToast("Copied to clipboard!", IconName.Copy)
                 },
             )
         }

--- a/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TagScreen.kt
+++ b/catalog/src/main/java/kiwi/orbit/compose/catalog/screens/TagScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -21,18 +19,18 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kiwi.orbit.compose.catalog.semantics.SubScreenSemantics
-import kiwi.orbit.compose.icons.Icons
+import kiwi.orbit.compose.icons.IconName
 import kiwi.orbit.compose.ui.OrbitTheme
 import kiwi.orbit.compose.ui.controls.Scaffold
 import kiwi.orbit.compose.ui.controls.Tag
 import kiwi.orbit.compose.ui.controls.Text
 import kiwi.orbit.compose.ui.controls.ToastHostState
 import kiwi.orbit.compose.ui.controls.TopAppBar
-import kotlinx.coroutines.launch
+import kiwi.orbit.compose.ui.controls.rememberToastHostState
 
 @Composable
 internal fun TagScreen(onNavigateUp: () -> Unit) {
-    val toastHostState = remember { ToastHostState() }
+    val toastHostState = rememberToastHostState()
     Scaffold(
         modifier = Modifier.testTag(SubScreenSemantics.Tag),
         topBar = {
@@ -57,11 +55,8 @@ internal fun TagScreen(onNavigateUp: () -> Unit) {
 @Composable
 private fun TagScreenInner(toastHostState: ToastHostState) {
     Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        val scope = rememberCoroutineScope()
         val onRemove: () -> Unit = {
-            scope.launch {
-                toastHostState.showToast("Tag removed.") { Icons.InformationCircle }
-            }
+            toastHostState.showToast("Tag removed.", IconName.InformationCircle)
         }
 
         Text("Non-interactive", style = OrbitTheme.typography.title4)

--- a/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/controls/Scaffold.kt
+++ b/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/controls/Scaffold.kt
@@ -65,7 +65,7 @@ public fun Scaffold(
             content = action,
         )
     },
-    toastHostState: ToastHostState = remember { ToastHostState() },
+    toastHostState: ToastHostState = rememberToastHostState(),
     toastHost: @Composable (ToastHostState) -> Unit = { ToastHost(it) },
     contentWindowInsets: WindowInsets = WindowInsets.ime,
     content: @Composable (contentPadding: PaddingValues) -> Unit,

--- a/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/controls/Toast.kt
+++ b/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/controls/Toast.kt
@@ -25,14 +25,14 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.platform.AccessibilityManager
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import kiwi.orbit.compose.icons.Icons
+import kiwi.orbit.compose.icons.IconName
+import kiwi.orbit.compose.icons.painter
 import kiwi.orbit.compose.ui.OrbitTheme
 import kiwi.orbit.compose.ui.controls.internal.OrbitPreviews
 import kiwi.orbit.compose.ui.controls.internal.Preview
@@ -49,7 +49,7 @@ import kotlinx.coroutines.launch
 
 public interface ToastData {
     public val message: String
-    public val icon: @Composable (() -> Painter)?
+    public val iconName: IconName?
 
     public val animationDuration: StateFlow<Duration?>
 
@@ -72,7 +72,7 @@ public fun Toast(
     key(toastData) {
         Toast(
             message = toastData.message,
-            icon = toastData.icon,
+            iconName = toastData.iconName,
             animateDuration = animateDuration,
             onPause = toastData::pause,
             onResume = toastData::resume,
@@ -84,7 +84,7 @@ public fun Toast(
 @Composable
 private fun Toast(
     message: String,
-    icon: @Composable (() -> Painter)?,
+    iconName: IconName?,
     animateDuration: Duration? = Duration.ZERO,
     onPause: () -> Unit = {},
     onResume: () -> Unit = {},
@@ -135,9 +135,9 @@ private fun Toast(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             ProvideMergedTextStyle(OrbitTheme.typography.bodyNormal) {
-                if (icon != null) {
+                if (iconName != null) {
                     Icon(
-                        icon(),
+                        iconName.painter(),
                         contentDescription = null,
                     )
                 }
@@ -233,15 +233,15 @@ internal fun ToastPreview() {
     Preview {
         Toast(
             message = "Message",
-            icon = null,
+            iconName = null,
         )
         Toast(
             message = "Message with icon",
-            icon = { Icons.CheckCircle },
+            iconName = IconName.CheckCircle,
         )
         Toast(
             message = "Message with icon and very long message with many words.",
-            icon = { Icons.CheckCircle },
+            iconName = IconName.CheckCircle,
         )
     }
 }


### PR DESCRIPTION
The currently displayed toast and any queued toasts are persisted through configuration changes.

 To achieve this, the ToastHostState has to rely on a callback rather than suspending function. This is a breaking change in the API.