### PR TITLE
Ensure that the height for layouting the topappbar is always at least…

### DIFF
--- a/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/controls/TopAppBar.kt
+++ b/ui/src/androidMain/kotlin/kiwi/orbit/compose/ui/controls/TopAppBar.kt
@@ -182,7 +182,7 @@ internal fun Modifier.scrollBehaviorLayout(
     if (scrollBehavior.state.heightOffsetLimit != heightOffsetLimit) {
         scrollBehavior.state.heightOffsetLimit = heightOffsetLimit
     }
-    val height = placeable.height + scrollBehavior.state.heightOffset.roundToInt()
+    val height = (placeable.height + scrollBehavior.state.heightOffset.roundToInt()).coerceAtLeast(0)
     layout(placeable.width, height) {
         placeable.place(0, height - placeable.height)
     }


### PR DESCRIPTION
… zero (in case placable has changed and the scrollstate lags behind)