### PR TITLE
Fix StringIndexOutOfBoundsException in LintUtils

### DIFF
--- a/lint/src/main/kotlin/kiwi/orbit/compose/lint/detectors/LintUtils.kt
+++ b/lint/src/main/kotlin/kiwi/orbit/compose/lint/detectors/LintUtils.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.isAncestor
+import org.jetbrains.kotlin.utils.addToStdlib.lastIndexOfOrNull
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.ULambdaExpression
 import org.jetbrains.uast.toUElement
@@ -36,7 +37,11 @@ internal fun PsiMethod.isInPackageName(packageName: String): Boolean {
 }
 
 internal fun PsiElement.getPackageName(): String? = when (this) {
-    is PsiMember -> this.containingClass?.qualifiedName?.let { it.substring(0, it.lastIndexOf(".")) }
+    is PsiMember -> this.containingClass?.qualifiedName?.let {
+        it.lastIndexOfOrNull('.')?.let { endIndex ->
+            it.substring(0, endIndex)
+        }
+    }
     else -> null
 }
 


### PR DESCRIPTION
Added a fix which prevents the following exception while running `gradlew updateLintBaseline`:

```
StringIndexOutOfBoundsException:Preconditions$1.apply(Preconditions.java:55)
Preconditions$1.apply(Preconditions.java:52)
Preconditions$4.apply(Preconditions.java:213)
Preconditions$4.apply(Preconditions.java:210)
Preconditions.outOfBounds(Preconditions.java:98)
Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
Preconditions.checkFromToIndex(Preconditions.java:349)
String.checkBoundsBeginEnd(String.java:4589)
String.substring(String.java:2703)
LintUtilsKt.getPackageName(LintUtils.kt:39)
MaterialDesignInsteadOrbitDesignDetector$createUastHandler$1.visitCallExpression(MaterialDesignInsteadOrbitDesignDetector.kt:35)
UElementVisitor$DispatchUastVisitor.visitCallExpression(UElementVisitor.kt:412)
UElementVisitor$DelegatingUastVisitor.visitCallExpression(UElementVisitor.kt:756)
UCallExpression.accept(UCallExpression.kt:94)
UQualifiedReferenceExpression.accept(UQualifiedReferenceExpression.kt:33)
UReturnExpression.accept(UReturnExpression.kt:22)
ImplementationUtilsKt.acceptList(implementationUtils.kt:15)
UBlockExpression.accept(UBlockExpression.kt:21)
ULambdaExpression.accept(ULambdaExpression.kt:40)
ImplementationUtilsKt.acceptList(implementationUtils.kt:15)
UCallExpression.accept(UCallExpression.kt:98)
UReturnExpression.accept(UReturnExpression.kt:22)
ImplementationUtilsKt.acceptList(implementationUtils.kt:15)
UBlockExpression.accept(UBlockExpression.kt:21)
ULambdaExpression.accept(ULambdaExpression.kt:40)
ImplementationUtilsKt.acceptList(implementationUtils.kt:15)
UCallExpression.accept(UCallExpression.kt:98)
KotlinUField.accept(KotlinUField.kt:59)
ImplementationUtilsKt.acceptList(implementationUtils.kt:15)
AbstractKotlinUClass.accept(AbstractKotlinUClass.kt:213)
ImplementationUtilsKt.acceptList(implementationUtils.kt:15)
UFile.accept(UFile.kt:89)
UastLintUtilsKt.acceptSourceFile(UastLintUtils.kt:953)
UElementVisitor$visitFile$3.run(UElementVisitor.kt:216)
LintClient.runReadAction(LintClient.kt:1781)
LintDriver$LintClientWrapper.runReadAction(LintDriver.kt:2747)
UElementVisitor.visitFile(UElementVisitor.kt:213)
LintDriver$visitUastDetectors$1.run(LintDriver.kt:2048)
LintClient.runReadAction(LintClient.kt:1781)
LintDriver$LintClientWrapper.runReadAction(LintDriver.kt:2747)
LintDriver.visitUastDetectors(LintDriver.kt:2048)
LintDriver.visitUast(LintDriver.kt:2010)
LintDriver.runFileDetectors(LintDriver.kt:1284)
LintDriver.checkProject(LintDriver.kt:1070)
LintDriver.checkProjectRoot(LintDriver.kt:622)
LintDriver.access$checkProjectRoot(LintDriver.kt:174)
LintDriver$analyzeOnly$1.invoke(LintDriver.kt:445)
LintDriver$analyzeOnly$1.invoke(LintDriver.kt:442)
LintDriver.doAnalyze(LintDriver.kt:501)
LintDriver.analyzeOnly(LintDriver.kt:442)
LintCliClient$analyzeOnly$1.invoke(LintCliClient.kt:258)
LintCliClient$analyzeOnly$1.invoke(LintCliClient.kt:255)
LintCliClient.run(LintCliClient.kt:312)
LintCliClient.analyzeOnly(LintCliClient.kt:255)
Main.run(Main.java:1766)
Main.run(Main.java:282)
DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
Method.invoke(Method.java:577)
AndroidLintWorkAction.invokeLintMainRunMethod(AndroidLintWorkAction.kt:103)
AndroidLintWorkAction.runLint(AndroidLintWorkAction.kt:90)
AndroidLintWorkAction.execute(AndroidLintWorkAction.kt:64)
DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:66)
NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:62)
ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:62)
AbstractWorker$1.call(AbstractWorker.java:44)
AbstractWorker$1.call(AbstractWorker.java:41)
DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:59)
DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:174)
FutureTask.run(FutureTask.java:264)
DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:194)
DefaultConditionalExecutionQueue$ExecutionRunner.access$700(DefaultConditionalExecutionQueue.java:127)
DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:169)
Factories$1.create(Factories.java:31)
DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:263)
DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:127)
DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:132)
DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:164)
DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:133)
Executors$RunnableAdapter.call(Executors.java:539)
FutureTask.run(FutureTask.java:264)
ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
Thread.run(Thread.java:833)
```
